### PR TITLE
First release with working CVs

### DIFF
--- a/Software/Open_Theremin_V4/application.cpp
+++ b/Software/Open_Theremin_V4/application.cpp
@@ -8,7 +8,7 @@
 #include "timer.h"
 #include "EEPROM.h"
 
-const AppMode AppModeValues[] = {MUTE,NORMAL};
+const AppMode AppModeValues[] = {MUTE, NORMAL};
 const int16_t CalibrationTolerance = 15;
 const int16_t PitchFreqOffset = 700;
 const int16_t VolumeFreqOffset = 700;
@@ -22,283 +22,312 @@ static int16_t pitchDAC = 0;
 static int16_t volumeDAC = 0;
 static float qMeasurement = 0;
 
-static int32_t volCalibrationBase   = 0;
+static int32_t volCalibrationBase = 0;
 
 Application::Application()
   : _state(PLAYING),
-    _mode(NORMAL) {
-};
+    _mode(NORMAL) {};
 
-void Application::setup() {
+void Application::setup()
+{
 #if SERIAL_ENABLED
   Serial.begin(Application::BAUD);
 #endif
 
-  HW_LED1_ON;HW_LED2_OFF;
+  HW_LED1_ON;
+  HW_LED2_OFF;
 
   pinMode(Application::BUTTON_PIN, INPUT_PULLUP);
-  pinMode(Application::LED_PIN_1,    OUTPUT);
-  pinMode(Application::LED_PIN_2,    OUTPUT);
+  pinMode(Application::LED_PIN_1, OUTPUT);
+  pinMode(Application::LED_PIN_2, OUTPUT);
 
-  digitalWrite(Application::LED_PIN_1, HIGH);    // turn the LED off by making the voltage LOW
+  digitalWrite(Application::LED_PIN_1, HIGH); // turn the LED off by making the voltage LOW
 
-   SPImcpDACinit();
+  SPImcpDACinit();
 
-EEPROM.get(0,pitchDAC);
-EEPROM.get(2,volumeDAC);
+  EEPROM.get(0, pitchDAC);
+  EEPROM.get(2, volumeDAC);
 
-SPImcpDAC2Asend(pitchDAC);
-SPImcpDAC2Bsend(volumeDAC);
+  SPImcpDAC2Asend(pitchDAC);
+  SPImcpDAC2Bsend(volumeDAC);
 
-  
-initialiseTimer();
-initialiseInterrupts();
+  initialiseTimer();
+  initialiseInterrupts();
 
-
-  EEPROM.get(4,pitchCalibrationBase);
-  EEPROM.get(8,volCalibrationBase);
- 
-
-
+  EEPROM.get(4, pitchCalibrationBase);
+  EEPROM.get(8, volCalibrationBase);
 }
 
-void Application::initialiseTimer() {
+void Application::initialiseTimer()
+{
   ihInitialiseTimer();
 }
 
-void Application::initialiseInterrupts() {
+void Application::initialiseInterrupts()
+{
   ihInitialiseInterrupts();
 }
 
-void Application::InitialisePitchMeasurement() {
-   ihInitialisePitchMeasurement();
+void Application::InitialisePitchMeasurement()
+{
+  ihInitialisePitchMeasurement();
 }
 
-void Application::InitialiseVolumeMeasurement() {
-   ihInitialiseVolumeMeasurement();
+void Application::InitialiseVolumeMeasurement()
+{
+  ihInitialiseVolumeMeasurement();
 }
 
 unsigned long Application::GetQMeasurement()
 {
-  int qn=0;
-  
-  TCCR1B = (1<<CS10);	
+  int qn = 0;
 
-while(!(PIND & (1<<PORTD3)));
-while((PIND & (1<<PORTD3)));
+  TCCR1B = (1 << CS10);
 
-TCNT1 = 0;
+  while (!(PIND & (1 << PORTD3)))
+    ;
+  while ((PIND & (1 << PORTD3)))
+    ;
+
+  TCNT1 = 0;
   timer_overflow_counter = 0;
-while(qn<31250){
-while(!(PIND & (1<<PORTD3)));
-qn++;
-while((PIND & (1<<PORTD3)));
-};
+  while (qn < 31250)
+  {
+    while (!(PIND & (1 << PORTD3)))
+      ;
+    qn++;
+    while ((PIND & (1 << PORTD3)))
+      ;
+  };
 
- 
-  
-  TCCR1B = 0;	
+  TCCR1B = 0;
 
- unsigned long frequency = TCNT1;
- unsigned long temp = 65536*(unsigned long)timer_overflow_counter;
+  unsigned long frequency = TCNT1;
+  unsigned long temp = 65536 * (unsigned long)timer_overflow_counter;
   frequency += temp;
 
-return frequency;
-
+  return frequency;
 }
-
 
 unsigned long Application::GetPitchMeasurement()
 {
   TCNT1 = 0;
   timer_overflow_counter = 0;
-  TCCR1B = (1<<CS12) | (1<<CS11) | (1<<CS10);	
+  TCCR1B = (1 << CS12) | (1 << CS11) | (1 << CS10);
 
-  delay(1000);  
-  
-  TCCR1B = 0;	
+  delay(1000);
 
- unsigned long frequency = TCNT1;
- unsigned long temp = 65536*(unsigned long)timer_overflow_counter;
+  TCCR1B = 0;
+
+  unsigned long frequency = TCNT1;
+  unsigned long temp = 65536 * (unsigned long)timer_overflow_counter;
   frequency += temp;
 
-return frequency;
-
+  return frequency;
 }
 
 unsigned long Application::GetVolumeMeasurement()
-{timer_overflow_counter = 0;
+{
+  timer_overflow_counter = 0;
 
-  TCNT0=0;
-  TCNT1=49911;
-  TCCR0B = (1<<CS02) | (1<<CS01) | (1<<CS00);	 // //External clock source on T0 pin. Clock on rising edge.
-  TIFR1  = (1<<TOV1);        //Timer1 INT Flag Reg: Clear Timer Overflow Flag
+  TCNT0 = 0;
+  TCNT1 = 49911;
+  TCCR0B = (1 << CS02) | (1 << CS01) | (1 << CS00); // //External clock source on T0 pin. Clock on rising edge.
+  TIFR1 = (1 << TOV1);                              //Timer1 INT Flag Reg: Clear Timer Overflow Flag
 
-while(!(TIFR1&((1<<TOV1)))); // on Timer 1 overflow (1s)
-  TCCR0B = 0;	 // Stop TimerCounter 0
- unsigned long frequency = TCNT0; // get counter 0 value
- unsigned long temp = (unsigned long)timer_overflow_counter; // and overflow counter
+  while (!(TIFR1 & ((1 << TOV1))))
+    ;                                                         // on Timer 1 overflow (1s)
+  TCCR0B = 0;                                                 // Stop TimerCounter 0
+  unsigned long frequency = TCNT0;                            // get counter 0 value
+  unsigned long temp = (unsigned long)timer_overflow_counter; // and overflow counter
 
- frequency += temp*256;
+  frequency += temp * 256;
 
-return frequency;
+  return frequency;
 }
 
-
-
-#if CV_ENABLED                                 // Initialise PWM Generator for CV output
-void initialiseCVOut() {
-
-}
-#endif
-
-AppMode Application::nextMode() {
+AppMode Application::nextMode()
+{
   return _mode == NORMAL ? MUTE : AppModeValues[_mode + 1];
 }
 
-void Application::loop() {
-  int32_t pitch_v = 0, pitch_l = 0;            // Last value of pitch  (for filtering)
-  int32_t vol_v = 0,   vol_l = 0;              // Last value of volume (for filtering)
+void Application::loop()
+{
+  int32_t pitch_v = 0, pitch_l = 0; // Last value of pitch  (for filtering)
+  int32_t vol_v = 0, vol_l = 0;     // Last value of volume (for filtering)
 
   uint16_t volumePotValue = 0;
   uint16_t pitchPotValue = 0;
-  int registerPotValue,registerPotValueL = 0;
-  int wavePotValue,wavePotValueL = 0;
+  int registerPotValue, registerPotValueL = 0;
+  int wavePotValue, wavePotValueL = 0;
   uint8_t registerValue = 2;
   uint16_t tmpVolume;
+  int16_t tmpPitch;
+  uint8_t tmpOct;
+  uint16_t tmpLog;
 
-  mloop:                   // Main loop avoiding the GCC "optimization"
+mloop: // Main loop avoiding the GCC "optimization"
 
-  pitchPotValue    = analogRead(PITCH_POT);
-  volumePotValue   = analogRead(VOLUME_POT);
-  registerPotValue   = analogRead(REGISTER_SELECT_POT);
+  pitchPotValue = analogRead(PITCH_POT);
+  volumePotValue = analogRead(VOLUME_POT);
+  registerPotValue = analogRead(REGISTER_SELECT_POT);
   wavePotValue = analogRead(WAVE_SELECT_POT);
-  
-  if ((registerPotValue-registerPotValueL) >= HYST_VAL || (registerPotValueL-registerPotValue) >= HYST_VAL) registerPotValueL=registerPotValue;
-  if (((wavePotValue-wavePotValueL) >= HYST_VAL) || ((wavePotValueL-wavePotValue) >= HYST_VAL)) wavePotValueL=wavePotValue;
 
-  vWavetableSelector=wavePotValueL>>7;
+  if ((registerPotValue - registerPotValueL) >= HYST_VAL || (registerPotValueL - registerPotValue) >= HYST_VAL)
+    registerPotValueL = registerPotValue;
+  if (((wavePotValue - wavePotValueL) >= HYST_VAL) || ((wavePotValueL - wavePotValue) >= HYST_VAL))
+    wavePotValueL = wavePotValue;
+
+  vWavetableSelector = wavePotValueL >> 7;
 
   // New register pot configuration:
   // Left = -1 octave, Center = +/- 0, Right = +1 octave
   if (registerPotValue > 681)
   {
-	  registerValue = 1;
-  } else if(registerPotValue < 342)
+    registerValue = 1;
+  }
+  else if (registerPotValue < 342)
   {
-	  registerValue = 3;
-  } else 
+    registerValue = 3;
+  }
+  else
   {
-	  registerValue = 2;
+    registerValue = 2;
   }
 
-  if (_state == PLAYING && HW_BUTTON_PRESSED) {
-   
+  if (_state == PLAYING && HW_BUTTON_PRESSED)
+  {
+
     resetTimer();
     _state = CALIBRATING;
     _mode = nextMode();
-    
 
- if (_mode==NORMAL) {HW_LED1_ON;HW_LED2_OFF;} else {HW_LED1_OFF;HW_LED2_ON;};
-   // playModeSettingSound();
-   
-   
-   
+    if (_mode == NORMAL)
+    {
+      HW_LED1_ON;
+      HW_LED2_OFF;
+    }
+    else
+    {
+      HW_LED1_OFF;
+      HW_LED2_ON;
+    };
+    // playModeSettingSound();
   }
 
-  if (_state == CALIBRATING && HW_BUTTON_RELEASED) {
-  
+  if (_state == CALIBRATING && HW_BUTTON_RELEASED)
+  {
+
     _state = PLAYING;
   };
 
-  if (_state == CALIBRATING && timerExpired(65000)) {
-      HW_LED1_ON;
-      HW_LED2_ON;
-      
-  playStartupSound();
-  
-   calibrate_pitch();
-   calibrate_volume();
+  if (_state == CALIBRATING && timerExpired(65000))
+  {
+    HW_LED1_ON;
+    HW_LED2_ON;
 
+    playStartupSound();
 
-   initialiseTimer();
-   initialiseInterrupts();
-   
-  playCalibratingCountdownSound();
-  calibrate();
-  
-  
-      
-      
+    calibrate_pitch();
+    calibrate_volume();
 
-      _mode=NORMAL;
-      HW_LED2_OFF;
-      
+    initialiseTimer();
+    initialiseInterrupts();
+
+    playCalibratingCountdownSound();
+    calibrate();
+
+    _mode = NORMAL;
+    HW_LED2_OFF;
+
     while (HW_BUTTON_PRESSED)
       ; // NOP
     _state = PLAYING;
   };
 
-#if CV_ENABLED
-  OCR0A = pitch & 0xff;
-#endif
-
-
-
 #if SERIAL_ENABLED
-  if (timerExpired(TICKS_100_MILLIS)) {
+  if (timerExpired(TICKS_100_MILLIS))
+  {
     resetTimer();
-    Serial.write(pitch & 0xff);              // Send char on serial (if used)
+    Serial.write(pitch & 0xff); // Send char on serial (if used)
     Serial.write((pitch >> 8) & 0xff);
   }
 #endif
 
-  if (pitchValueAvailable) {                        // If capture event
+  if (pitchValueAvailable)
+  { // If capture event
 
-    pitch_v=pitch;                         // Averaging pitch values
-    pitch_v=pitch_l+((pitch_v-pitch_l)>>2);
-    pitch_l=pitch_v;
+    pitch_v = pitch; // Averaging pitch values
+    pitch_v = pitch_l + ((pitch_v - pitch_l) >> 2);
+    pitch_l = pitch_v;
 
-//HW_LED2_ON;
-
+    //HW_LED2_ON;
 
     // set wave frequency for each mode
-    switch (_mode) {
-      case MUTE : /* NOTHING! */;                                        break;
-      case NORMAL      : setWavetableSampleAdvance(((pitchCalibrationBase-pitch_v)+2048-(pitchPotValue<<2))>>registerValue); break;
+    switch (_mode)
+    {
+      case MUTE: /* NOTHING! */;
+        break;
+      case NORMAL:
+        tmpPitch = ((pitchCalibrationBase - pitch_v) + 2048 - (pitchPotValue << 2));
+        tmpPitch = min(tmpPitch, 16383);  // Unaudible upper limit just to prevent DAC overflow
+        tmpPitch = max(tmpPitch, 0);      // Silence behing zero beat
+        setWavetableSampleAdvance(tmpPitch >> registerValue);
+#if CV_LOG
+        tmpOct = 0;
+        while (tmpPitch > 1023) {
+          tmpOct += 1;
+          tmpPitch >>= 1;
+        }
+        tmpPitch = max(tmpPitch, 512) - 512;
+        tmpLog = ((uint16_t)tmpPitch >> 3) * 819 >> 6;
+        pitchCV = max(tmpOct * 820 + tmpLog - 48, 0);  // ~1V/Oct for Moog & Roland
+#else
+        pitchCV = tmpPitch >> 2;                       // ~800Hz/V for Korg & Yamaha
+#endif
+        pitchCVAvailable = true;
+        break;
     };
-    
-  //  HW_LED2_OFF;
+
+    //  HW_LED2_OFF;
 
     pitchValueAvailable = false;
   }
 
-  if (volumeValueAvailable) {
+  if (volumeValueAvailable)
+  {
     vol = max(vol, 5000);
 
-    vol_v=vol;                  // Averaging volume values
-    vol_v=vol_l+((vol_v-vol_l)>>2);
-    vol_l=vol_v;
+    vol_v = vol; // Averaging volume values
+    vol_v = vol_l + ((vol_v - vol_l) >> 2);
+    vol_l = vol_v;
 
-    switch (_mode) {
-      case MUTE:  vol_v = 0;                                                      break;
-      case NORMAL:      vol_v = MAX_VOLUME-(volCalibrationBase-vol_v)/2+(volumePotValue<<2)-1024;                                     break;
+    switch (_mode)
+    {
+      case MUTE:
+        vol_v = 0;
+        break;
+      case NORMAL:
+        vol_v = MAX_VOLUME - (volCalibrationBase - vol_v) / 2 + (volumePotValue << 2) - 1024;
+        break;
     };
 
     // Limit and set volume value
     vol_v = min(vol_v, 4095);
-    //    vol_v = vol_v - (1 + MAX_VOLUME - (volumePotValue << 2));
-    vol_v = vol_v ;
     vol_v = max(vol_v, 0);
     tmpVolume = vol_v >> 4;
-	
-	// Give vScaledVolume a pseudo-exponential characteristic:
-	vScaledVolume = tmpVolume * (tmpVolume + 2);
 
-	volumeValueAvailable = false;
+    // Most synthesizers "exponentiate" the volume CV themselves, thus send the "raw" volume for CV:
+    volCV = vol_v;
+    volumeCVAvailable = true;
+
+    // Give vScaledVolume a pseudo-exponential characteristic:
+    vScaledVolume = tmpVolume * (tmpVolume + 2);
+
+    volumeValueAvailable = false;
   }
 
-  goto mloop;                           // End of main loop
+  goto mloop; // End of main loop
 }
 
 void Application::calibrate()
@@ -309,8 +338,8 @@ void Application::calibrate()
   while (!pitchValueAvailable && timerUnexpiredMillis(10))
     ; // NOP
   pitchCalibrationBase = pitch;
-  pitchCalibrationBaseFreq = FREQ_FACTOR/pitchCalibrationBase;
-  pitchCalibrationConstant = FREQ_FACTOR/pitchSensitivityConstant/2+200;
+  pitchCalibrationBaseFreq = FREQ_FACTOR / pitchCalibrationBase;
+  pitchCalibrationConstant = FREQ_FACTOR / pitchSensitivityConstant / 2 + 200;
 
   resetVolFlag();
   resetTimer();
@@ -318,215 +347,210 @@ void Application::calibrate()
   while (!volumeValueAvailable && timerUnexpiredMillis(10))
     ; // NOP
   volCalibrationBase = vol;
-  
-  
-  EEPROM.put(4,pitchCalibrationBase);
-  EEPROM.put(8,volCalibrationBase);
-  
+
+  EEPROM.put(4, pitchCalibrationBase);
+  EEPROM.put(8, volCalibrationBase);
 }
 
 void Application::calibrate_pitch()
 {
-  
-static int16_t pitchXn0 = 0;
-static int16_t pitchXn1 = 0;
-static int16_t pitchXn2 = 0;
-static float q0 = 0;
-static long pitchfn0 = 0;
-static long pitchfn1 = 0;
-static long pitchfn = 0;
+
+  static int16_t pitchXn0 = 0;
+  static int16_t pitchXn1 = 0;
+  static int16_t pitchXn2 = 0;
+  static float q0 = 0;
+  static long pitchfn0 = 0;
+  static long pitchfn1 = 0;
+  static long pitchfn = 0;
 
   Serial.begin(115200);
   Serial.println("\nPITCH CALIBRATION\n");
 
   HW_LED1_ON;
   HW_LED2_ON;
-  
+
   InitialisePitchMeasurement();
   interrupts();
   SPImcpDACinit();
 
-  qMeasurement = GetQMeasurement();  // Measure Arudino clock frequency 
+  qMeasurement = GetQMeasurement(); // Measure Arudino clock frequency
   Serial.print("Arudino Freq: ");
   Serial.println(qMeasurement);
 
-q0 = (16000000/qMeasurement*500000);  //Calculated set frequency based on Arudino clock frequency
+  q0 = (16000000 / qMeasurement * 500000); //Calculated set frequency based on Arudino clock frequency
 
-pitchXn0 = 0;
-pitchXn1 = 4095;
+  pitchXn0 = 0;
+  pitchXn1 = 4095;
 
-pitchfn = q0-PitchFreqOffset;        // Add offset calue to set frequency
+  pitchfn = q0 - PitchFreqOffset; // Add offset calue to set frequency
 
-Serial.print("\nPitch Set Frequency: ");
-Serial.println(pitchfn);
+  Serial.print("\nPitch Set Frequency: ");
+  Serial.println(pitchfn);
 
+  SPImcpDAC2Bsend(1600);
 
-SPImcpDAC2Bsend(1600);
+  SPImcpDAC2Asend(pitchXn0);
+  delay(100);
+  pitchfn0 = GetPitchMeasurement();
 
-SPImcpDAC2Asend(pitchXn0);
-delay(100);
-pitchfn0 = GetPitchMeasurement();
+  SPImcpDAC2Asend(pitchXn1);
+  delay(100);
+  pitchfn1 = GetPitchMeasurement();
 
-SPImcpDAC2Asend(pitchXn1);
-delay(100);
-pitchfn1 = GetPitchMeasurement();
+  Serial.print("Frequency tuning range: ");
+  Serial.print(pitchfn0);
+  Serial.print(" to ");
+  Serial.println(pitchfn1);
 
-Serial.print ("Frequency tuning range: ");
-Serial.print(pitchfn0);
-Serial.print(" to ");
-Serial.println(pitchfn1);
-  
- 
-while(abs(pitchfn0-pitchfn1)>CalibrationTolerance){      // max allowed pitch frequency offset
+  while (abs(pitchfn0 - pitchfn1) > CalibrationTolerance)
+  { // max allowed pitch frequency offset
 
-SPImcpDAC2Asend(pitchXn0);
-delay(100);
-pitchfn0 = GetPitchMeasurement()-pitchfn;
+    SPImcpDAC2Asend(pitchXn0);
+    delay(100);
+    pitchfn0 = GetPitchMeasurement() - pitchfn;
 
-SPImcpDAC2Asend(pitchXn1);
-delay(100);
-pitchfn1 = GetPitchMeasurement()-pitchfn;
+    SPImcpDAC2Asend(pitchXn1);
+    delay(100);
+    pitchfn1 = GetPitchMeasurement() - pitchfn;
 
-pitchXn2=pitchXn1-((pitchXn1-pitchXn0)*pitchfn1)/(pitchfn1-pitchfn0); // new DAC value
+    pitchXn2 = pitchXn1 - ((pitchXn1 - pitchXn0) * pitchfn1) / (pitchfn1 - pitchfn0); // new DAC value
 
-Serial.print("\nDAC value L: ");
-Serial.print(pitchXn0);
-Serial.print(" Freq L: ");
-Serial.println(pitchfn0);
-Serial.print("DAC value H: ");
-Serial.print(pitchXn1);
-Serial.print(" Freq H: ");
-Serial.println(pitchfn1);
+    Serial.print("\nDAC value L: ");
+    Serial.print(pitchXn0);
+    Serial.print(" Freq L: ");
+    Serial.println(pitchfn0);
+    Serial.print("DAC value H: ");
+    Serial.print(pitchXn1);
+    Serial.print(" Freq H: ");
+    Serial.println(pitchfn1);
 
+    pitchXn0 = pitchXn1;
+    pitchXn1 = pitchXn2;
 
-pitchXn0 = pitchXn1;
-pitchXn1 = pitchXn2;
+    HW_LED1_TOGGLE;
+  }
+  delay(100);
 
-HW_LED1_TOGGLE;
-
-}
-delay(100);
-
-EEPROM.put(0,pitchXn0);
-  
+  EEPROM.put(0, pitchXn0);
 }
 
 void Application::calibrate_volume()
 {
 
+  static int16_t volumeXn0 = 0;
+  static int16_t volumeXn1 = 0;
+  static int16_t volumeXn2 = 0;
+  static float q0 = 0;
+  static long volumefn0 = 0;
+  static long volumefn1 = 0;
+  static long volumefn = 0;
 
-static int16_t volumeXn0 = 0;
-static int16_t volumeXn1 = 0;
-static int16_t volumeXn2 = 0;
-static float q0 = 0;
-static long volumefn0 = 0;
-static long volumefn1 = 0;
-static long volumefn = 0;
+  Serial.begin(115200);
+  Serial.println("\nVOLUME CALIBRATION");
 
-    Serial.begin(115200);
-    Serial.println("\nVOLUME CALIBRATION");
-    
   InitialiseVolumeMeasurement();
   interrupts();
   SPImcpDACinit();
 
+  volumeXn0 = 0;
+  volumeXn1 = 4095;
 
-volumeXn0 = 0;
-volumeXn1 = 4095;
+  q0 = (16000000 / qMeasurement * 460765);
+  volumefn = q0 - VolumeFreqOffset;
 
-q0 = (16000000/qMeasurement*460765);
-volumefn = q0-VolumeFreqOffset;
+  Serial.print("\nVolume Set Frequency: ");
+  Serial.println(volumefn);
 
-Serial.print("\nVolume Set Frequency: ");
-Serial.println(volumefn);
+  SPImcpDAC2Bsend(volumeXn0);
+  delay_NOP(44316); //44316=100ms
 
+  volumefn0 = GetVolumeMeasurement();
 
-SPImcpDAC2Bsend(volumeXn0);
-delay_NOP(44316);//44316=100ms
+  SPImcpDAC2Bsend(volumeXn1);
 
-volumefn0 = GetVolumeMeasurement();
+  delay_NOP(44316); //44316=100ms
+  volumefn1 = GetVolumeMeasurement();
 
-SPImcpDAC2Bsend(volumeXn1);
+  Serial.print("Frequency tuning range: ");
+  Serial.print(volumefn0);
+  Serial.print(" to ");
+  Serial.println(volumefn1);
 
-delay_NOP(44316);//44316=100ms
-volumefn1 = GetVolumeMeasurement();
+  while (abs(volumefn0 - volumefn1) > CalibrationTolerance)
+  {
 
+    SPImcpDAC2Bsend(volumeXn0);
+    delay_NOP(44316); //44316=100ms
+    volumefn0 = GetVolumeMeasurement() - volumefn;
 
-Serial.print ("Frequency tuning range: ");
-Serial.print(volumefn0);
-Serial.print(" to ");
-Serial.println(volumefn1);
+    SPImcpDAC2Bsend(volumeXn1);
+    delay_NOP(44316); //44316=100ms
+    volumefn1 = GetVolumeMeasurement() - volumefn;
 
+    volumeXn2 = volumeXn1 - ((volumeXn1 - volumeXn0) * volumefn1) / (volumefn1 - volumefn0); // calculate new DAC value
 
-while(abs(volumefn0-volumefn1)>CalibrationTolerance){
+    Serial.print("\nDAC value L: ");
+    Serial.print(volumeXn0);
+    Serial.print(" Freq L: ");
+    Serial.println(volumefn0);
+    Serial.print("DAC value H: ");
+    Serial.print(volumeXn1);
+    Serial.print(" Freq H: ");
+    Serial.println(volumefn1);
 
-SPImcpDAC2Bsend(volumeXn0);
-delay_NOP(44316);//44316=100ms
-volumefn0 = GetVolumeMeasurement()-volumefn;
+    volumeXn0 = volumeXn1;
+    volumeXn1 = volumeXn2;
+    HW_LED1_TOGGLE;
+  }
 
-SPImcpDAC2Bsend(volumeXn1);
-delay_NOP(44316);//44316=100ms
-volumefn1 = GetVolumeMeasurement()-volumefn;
-
-volumeXn2=volumeXn1-((volumeXn1-volumeXn0)*volumefn1)/(volumefn1-volumefn0); // calculate new DAC value
-
-Serial.print("\nDAC value L: ");
-Serial.print(volumeXn0);
-Serial.print(" Freq L: ");
-Serial.println(volumefn0);
-Serial.print("DAC value H: ");
-Serial.print(volumeXn1);
-Serial.print(" Freq H: ");
-Serial.println(volumefn1);
-
-
-volumeXn0 = volumeXn1;
-volumeXn1 = volumeXn2;
-HW_LED1_TOGGLE;
-
-}
-
-EEPROM.put(2,volumeXn0);
+  EEPROM.put(2, volumeXn0);
 
   HW_LED1_ON;
   HW_LED2_OFF;
 
-
   Serial.println("\nCALIBRATION COMPLETED\n");
 }
 
-void Application::hzToAddVal(float hz) {
+void Application::hzToAddVal(float hz)
+{
   setWavetableSampleAdvance((uint16_t)(hz * HZ_ADDVAL_FACTOR));
 }
 
-void Application::playNote(float hz, uint16_t milliseconds = 500, uint8_t volume = 255) {
+void Application::playNote(float hz, uint16_t milliseconds = 500, uint8_t volume = 255)
+{
   vScaledVolume = volume * (volume + 2);
   hzToAddVal(hz);
   millitimer(milliseconds);
   vScaledVolume = 0;
 }
 
-void Application::playStartupSound() {
+void Application::playStartupSound()
+{
   playNote(MIDDLE_C, 150, 25);
   playNote(MIDDLE_C * 2, 150, 25);
   playNote(MIDDLE_C * 4, 150, 25);
 }
 
-void Application::playCalibratingCountdownSound() {
+void Application::playCalibratingCountdownSound()
+{
   playNote(MIDDLE_C * 2, 150, 25);
   playNote(MIDDLE_C * 2, 150, 25);
 }
 
-void Application::playModeSettingSound() {
-  for (int i = 0; i <= _mode; i++) {
+void Application::playModeSettingSound()
+{
+  for (int i = 0; i <= _mode; i++)
+  {
     playNote(MIDDLE_C * 2, 200, 25);
     millitimer(100);
   }
 }
 
-void Application::delay_NOP(unsigned long time) {
+void Application::delay_NOP(unsigned long time)
+{
   volatile unsigned long i = 0;
-  for (i = 0; i < time; i++) {
-      __asm__ __volatile__ ("nop");
+  for (i = 0; i < time; i++)
+  {
+    __asm__ __volatile__("nop");
   }
 }

--- a/Software/Open_Theremin_V4/build.h
+++ b/Software/Open_Theremin_V4/build.h
@@ -7,8 +7,8 @@
 // Set to build with serial support
 #define SERIAL_ENABLED 0
 
-// Set to build with control voltage output (experimental)
-#define CV_ENABLED 0
+// Set to build with logarithmic 1V/oct pitch control voltage output
+#define CV_LOG 1
 
 
 #endif // _BUILD_H

--- a/Software/Open_Theremin_V4/ihandlers.cpp
+++ b/Software/Open_Theremin_V4/ihandlers.cpp
@@ -14,21 +14,20 @@
 #include "theremin_sintable7.c"
 #include "theremin_sintable8.c"
 
-const int16_t* const wavetables[] = { //Fixed following a suggestion by Michael Freitas, does not need to be in PROGMEM
-  sine_table,
-  sine_table2,
-  sine_table3,
-  sine_table4,
-  sine_table5,
-  sine_table6,
-  sine_table7,
-  sine_table8
-};
+const int16_t *const wavetables[] = { //Fixed following a suggestion by Michael Freitas, does not need to be in PROGMEM
+    sine_table,
+    sine_table2,
+    sine_table3,
+    sine_table4,
+    sine_table5,
+    sine_table6,
+    sine_table7,
+    sine_table8};
 
 static const uint32_t MCP_DAC_BASE = 2048;
 
-#define INT0_STATE    (PIND & (1<<PORTD2))
-#define PC_STATE      (PINB & (1<<PORTB0))
+#define INT0_STATE (PIND & (1 << PORTD2))
+#define PC_STATE (PINB & (1 << PORTB0))
 
 // Added by ThF 20200419
 // #define TH_DEBUG 			// <-- comment this out for normal operation
@@ -41,160 +40,180 @@ static const uint32_t MCP_DAC_BASE = 2048;
 volatile uint16_t vScaledVolume = 0;
 volatile uint16_t vPointerIncrement = 0;
 
-volatile uint16_t pitch = 0;            // Pitch value
-volatile uint16_t pitch_counter = 0;    // Pitch counter
-volatile uint16_t pitch_counter_l = 0;  // Last value of pitch counter
+volatile uint16_t pitch = 0;           // Pitch value
+volatile uint16_t pitch_counter = 0;   // Pitch counter
+volatile uint16_t pitch_counter_l = 0; // Last value of pitch counter
 
-volatile bool volumeValueAvailable = 0;  // Volume read flag
-volatile bool pitchValueAvailable = 0;   // Pitch read flag
-volatile bool reenableInt1 = 0;   // reeanble Int1
+volatile bool volumeValueAvailable = 0; // Volume read flag
+volatile bool pitchValueAvailable = 0;  // Pitch read flag
+volatile bool reenableInt1 = 0;         // reeanble Int1
 
-volatile uint16_t vol;                   // Volume value
+volatile uint16_t vol; // Volume value
 volatile uint16_t vol_counter = 0;
-volatile uint16_t vol_counter_i = 0;     // Volume counter
-volatile uint16_t vol_counter_l;         // Last value of volume counter
+volatile uint16_t vol_counter_i = 0; // Volume counter
+volatile uint16_t vol_counter_l;     // Last value of volume counter
 
-volatile uint16_t timer_overflow_counter;         // counter for frequency measurement
+volatile uint16_t pitchCV;              // Pitch CV value
+volatile uint16_t volCV;                // Volume CV value
+volatile bool volumeCVAvailable;   // Volume CV flag
+volatile bool pitchCVAvailable;    // Pitch CV flag
 
-volatile uint8_t vWavetableSelector = 0;  // wavetable selector
 
-static volatile uint16_t pointer       = 0;  // Table pointer
-static volatile uint8_t  debounce_p, debounce_v  = 0;  // Counters for debouncing
+volatile uint16_t timer_overflow_counter; // counter for frequency measurement
 
-void ihInitialiseTimer() {
+volatile uint8_t vWavetableSelector = 0; // wavetable selector
+
+static volatile uint16_t pointer = 0;               // Table pointer
+static volatile uint8_t debounce_p, debounce_v = 0; // Counters for debouncing
+
+void ihInitialiseTimer()
+{
   /* Setup Timer 1, 16 bit timer used to measure pitch and volume frequency */
-  TCCR1A = 0;                     // Set Timer 1 to Normal port operation (Arduino does activate something here ?)
-  TCCR1B = (1<<ICES1)|(1<<CS10);  // Input Capture Positive edge select, Run without prescaling (16 Mhz)
-  TIMSK1 = (1<<ICIE1);            // Enable Input Capture Interrupt
-  
+  TCCR1A = 0;                          // Set Timer 1 to Normal port operation (Arduino does activate something here ?)
+  TCCR1B = (1 << ICES1) | (1 << CS10); // Input Capture Positive edge select, Run without prescaling (16 Mhz)
+  TIMSK1 = (1 << ICIE1);               // Enable Input Capture Interrupt
+
   TCCR0A = 3; //Arduino Default: Fast PWM
   TCCR0B = 3; //Arduino Default: clk I/O /64 (From prescaler)
   TIMSK0 = 1; //Arduino Default: TOIE0: Timer/Counter0 Overflow Interrupt Enable
-  
 }
 
-void ihInitialiseInterrupts() {
+void ihInitialiseInterrupts()
+{
   /* Setup interrupts for Wave Generator and Volume read */
-  EICRA = (1<<ISC00)|(1<<ISC01)|(1<<ISC11)|(1<<ISC10) ; // The rising edges of INT0 and INT1 generate an interrupt request.
+  EICRA = (1 << ISC00) | (1 << ISC01) | (1 << ISC11) | (1 << ISC10); // The rising edges of INT0 and INT1 generate an interrupt request.
   reenableInt1 = true;
-  EIMSK = (1<<INT0)|(1<<INT1);                          // Enable External Interrupt INT0 and INT1
+  EIMSK = (1 << INT0) | (1 << INT1); // Enable External Interrupt INT0 and INT1
 }
 
 void ihInitialisePitchMeasurement() //Measurement of variable frequency oscillator on Timer 1
-{   reenableInt1 = false;
-    EIMSK =  0; // Disable External Interrupts
-    TCCR1A = 0;           //Normal port operation Timer 1
-    TIMSK1 = (1<<TOIE1);  //Timer/Counter1, Overflow Interrupt Enable
-   
-  }
-  
+{
+  reenableInt1 = false;
+  EIMSK = 0;             // Disable External Interrupts
+  TCCR1A = 0;            //Normal port operation Timer 1
+  TIMSK1 = (1 << TOIE1); //Timer/Counter1, Overflow Interrupt Enable
+}
+
 void ihInitialiseVolumeMeasurement() //Measurement of variable frequency oscillator on Timer 0
-{   reenableInt1 = false;
-    EIMSK =  0; // Disable External Interrupts
-    TIMSK1 = 0; //Timer/Counter1, Overflow Interrupt Disable
+{
+  reenableInt1 = false;
+  EIMSK = 0;  // Disable External Interrupts
+  TIMSK1 = 0; //Timer/Counter1, Overflow Interrupt Disable
 
-    TCCR0A = 0; // Normal port operation, OC0A disconnected. Timer 0
-    TIMSK0 = (1<<OCIE0A);  //TOIE0: Timer/Counter0 Overflow Interrupt Enable
-    OCR0A = 0xff; // set Output Compare Register0.
-    
-    TCCR1A = 0;  //Normal port operation Timer 1
-    TCCR1B = (1<<CS10)|(1<<CS12); // clk I/O /1024 (From prescaler)
-    TCCR1C=0;
+  TCCR0A = 0;             // Normal port operation, OC0A disconnected. Timer 0
+  TIMSK0 = (1 << OCIE0A); //TOIE0: Timer/Counter0 Overflow Interrupt Enable
+  OCR0A = 0xff;           // set Output Compare Register0.
 
-    
-  }
+  TCCR1A = 0;                         //Normal port operation Timer 1
+  TCCR1B = (1 << CS10) | (1 << CS12); // clk I/O /1024 (From prescaler)
+  TCCR1C = 0;
+}
 
 /* Externaly generated 31250 Hz Interrupt for WAVE generator (32us) */
-ISR (INT1_vect) {
-  // Interrupt takes up normally 14us but can take up to 22us when interrupted by another interrupt.
+ISR(INT1_vect)
+{
+// Interrupt takes up normally 14us but can take up to 22us when interrupted by another interrupt.
 
-  // Added by ThF 20200419
-  #ifdef TH_DEBUG
-    HW_LED2_ON;
-  #endif
+// Added by ThF 20200419
+#ifdef TH_DEBUG
+  HW_LED2_ON;
+#endif
 
   // Latch previously written DAC value:
   SPImcpDAClatch();
 
-	disableInt1(); // Disable External Interrupt INT1 to avoid recursive interrupts
-	// Enable Interrupts to allow counter 1 interrupts
-	interrupts();
+  disableInt1(); // Disable External Interrupt INT1 to avoid recursive interrupts
+  // Enable Interrupts to allow counter 1 interrupts
+  interrupts();
 
-	int16_t waveSample;
-	uint32_t scaledSample = 0;
-	uint16_t offset = (uint16_t)(pointer >> 6) & 0x3ff;
+  int16_t waveSample;
+  uint32_t scaledSample = 0;
+  uint16_t offset = (uint16_t)(pointer >> 6) & 0x3ff;
 
-#if CV_ENABLED                                 // Generator for CV output
+  // Play sound:
+  // Read next wave table value
+  waveSample = (int16_t)pgm_read_word_near(wavetables[vWavetableSelector] + offset);
+  // scale with volume
+  scaledSample = ((int32_t)waveSample * (uint32_t)vScaledVolume) >> 16; // The compiler optimizes this better than any assembly written by hand !!!
+  // send out
+  SPImcpDACsend(scaledSample + MCP_DAC_BASE); //Send result to Digital to Analogue Converter (audio out) (5.5 us)
+  // move on:
+  pointer += vPointerIncrement; // increment table pointer
 
- vPointerIncrement = min(vPointerIncrement, 4095);
- SPImcpDACsend(vPointerIncrement);        //Send result to Digital to Analogue Converter (audio out) (5.5 us)
+  incrementTimer(); // update 32us timer
 
-#else   //Play sound
- SPImcpDAC3Asend(vPointerIncrement);        //Send result to Digital to Analogue Converter (audio out) (5.5 us)
- SPImcpDAC3Bsend(vScaledVolume>> 5);        //Send result to Digital to Analogue Converter (audio out) (5.5 us)
-
-	// Read next wave table value
-	waveSample = (int16_t)pgm_read_word_near(wavetables[vWavetableSelector] + offset);
-
-	scaledSample = ((int32_t)waveSample * (uint32_t)vScaledVolume) >> 16; // The compiler optimizes this better than any assembly written by hand !!!
-
-	SPImcpDACsend(scaledSample + MCP_DAC_BASE); //Send result to Digital to Analogue Converter (audio out) (5.5 us)
-
-	pointer += vPointerIncrement; // increment table pointer
-
-#endif                          //CV play sound
-  incrementTimer();               // update 32us timer
-
-  if (PC_STATE) debounce_p++;
-  if (debounce_p == 3) {
+  if (PC_STATE)
+    debounce_p++;
+  if (debounce_p == 3)
+  {
     noInterrupts();
     pitch_counter = ICR1;                      // Get Timer-Counter 1 value
     pitch = (pitch_counter - pitch_counter_l); // Counter change since last interrupt -> pitch value
     pitch_counter_l = pitch_counter;           // Set actual value as new last value
   };
 
-  if (debounce_p == 5) {
+  if (debounce_p == 5)
+  {
     pitchValueAvailable = true;
   };
 
-  if (INT0_STATE) debounce_v++;
-  if (debounce_v == 3) {
+  if (INT0_STATE)
+    debounce_v++;
+  if (debounce_v == 3)
+  {
     noInterrupts();
-    vol_counter = vol_counter_i;            // Get Timer-Counter 1 value
-    vol = (vol_counter - vol_counter_l);    // Counter change since last interrupt
-    vol_counter_l = vol_counter;            // Set actual value as new last value
+    vol_counter = vol_counter_i;         // Get Timer-Counter 1 value
+    vol = (vol_counter - vol_counter_l); // Counter change since last interrupt
+    vol_counter_l = vol_counter;         // Set actual value as new last value
   };
 
-  if (debounce_v == 5) {
+  if (debounce_v == 5)
+  {
     volumeValueAvailable = true;
   };
+  // Output CV only if new values available
+  /* 
+ * At the very end to limit potential interference with sound generation
+ * Priority on pitchCV, volumeCV if occurring at the same moment might be delayed by 32us without harm,
+ * but it's better to do max. 1 additional SPI transaction per interrupt do leave enough headroom for the loop.
+ */
+  if (pitchCVAvailable)
+  {
+    SPImcpDAC3Asend(pitchCV); //Send result to Digital to Analogue Converter (pitchCV out) (5.5 us)
+    pitchCVAvailable=false;   //Reset flag
+  }
+  else if (volumeCVAvailable)
+  {
+    SPImcpDAC3Bsend(volCV);   //Send result to Digital to Analogue Converter (volCV out) (5.5 us)
+    volumeCVAvailable=false;  //Reset flag
+  }
 
   noInterrupts();
   enableInt1();
 // Added by ThF 20200419
 #ifdef TH_DEBUG
-	HW_LED2_OFF;
+  HW_LED2_OFF;
 #endif
 }
 
 /* VOLUME read - interrupt service routine for capturing volume counter value */
-ISR (INT0_vect) {
+ISR(INT0_vect)
+{
   vol_counter_i = TCNT1;
   debounce_v = 0;
 };
 
-
 /* PITCH read - interrupt service routine for capturing pitch counter value */
-ISR (TIMER1_CAPT_vect) {
+ISR(TIMER1_CAPT_vect)
+{
   debounce_p = 0;
 };
-
 
 /* PITCH read absolute frequency - interrupt service routine for calibration measurement */
 ISR(TIMER0_COMPA_vect)
 {
   timer_overflow_counter++;
-  }
+}
 
 /* VOLUME read absolute frequency - interrupt service routine for calibration measurement */
 ISR(TIMER1_OVF_vect)

--- a/Software/Open_Theremin_V4/ihandlers.h
+++ b/Software/Open_Theremin_V4/ihandlers.h
@@ -3,7 +3,9 @@
 
 extern volatile uint16_t pitch;              // Pitch value
 extern volatile uint16_t vol;                // Volume value
-extern volatile uint16_t  vScaledVolume;      // Volume byte
+extern volatile uint16_t vScaledVolume;      // Volume byte
+extern volatile uint16_t pitchCV;              // Pitch CV value
+extern volatile uint16_t volCV;                // Volume CV value
 
 extern volatile uint16_t pitch_counter;      // Pitch counter
 extern volatile uint16_t pitch_counter_l;    // Last value of pitch counter
@@ -16,6 +18,8 @@ extern volatile uint16_t timer_overflow_counter;         // counter for frequenc
 
 extern volatile bool volumeValueAvailable;   // Volume read flag
 extern volatile bool pitchValueAvailable;    // Pitch read flag
+extern volatile bool volumeCVAvailable;   // Volume CV flag
+extern volatile bool pitchCVAvailable;    // Pitch CV flag
 extern volatile bool reenableInt1;    // Pitch read flag
 
 extern volatile uint8_t  vWavetableSelector;


### PR DESCRIPTION
+ Added CV processing and output over DAC3a/3b. DACs are only updated when a new pitch or volume CV value exists, not systematically in each ISR1. If both values are available at the same time, the pitch CV will be sent first and the vol CV will be delayed until the next interrupt without harm (32us...). The pitch CV does not follow the register switch to always use the full 0-5V DAC range and resolution.
- Removed (hopefully all) cadavers from earlier (V3.x and V4.0 beta) experimental CV stuff
+ Added a compiler switch in build.h: CV_LOG. If 1 then, the pitch CV output is ~1V/oct for Moog & Roland Synths (most common standard). If 0 then it is 800Hz/V for Korg, some Yamaha and many simple modular DIY Synths.
+ Volume CV is sent flat without enhancement since all known synths do some (pseudo-)exponentiation by themselves.
-+- My IDE used auto-formatting for the code which makes it look with much more changes than there are really. Sorry for that...