### PR TITLE
fixed compile error and corrected UI colors

### DIFF
--- a/Software/Open_Theremin_V4/application.cpp
+++ b/Software/Open_Theremin_V4/application.cpp
@@ -11,7 +11,7 @@ typedef enum { CALIBRATING = 0, PLAYING } theremin_state_t;
 // storage state global var
 theremin_state_t g_state = PLAYING;
 // audio output state global var
-bool g_audio_output_is_enabled = false;
+bool g_audio_output_is_enabled = true;
 
 static const uint16_t MAX_VOLUME = 4095;
 
@@ -107,7 +107,7 @@ void theremin_setup() {
     pinMode(LED_BLUE_PIN, OUTPUT);
     pinMode(LED_RED_PIN, OUTPUT);
 
-    HW_LED_BLUE_ON; HW_LED_RED_OFF;
+    HW_LED_BLUE_OFF; HW_LED_RED_ON;
 
     // initialize potentiometer position at startup
     // force update for correct initialization
@@ -138,9 +138,9 @@ mloop: // Main loop avoiding the GCC "optimization"
         g_state = CALIBRATING;
         g_audio_output_is_enabled = !g_audio_output_is_enabled;
         if (g_audio_output_is_enabled) {
-            HW_LED_BLUE_ON; HW_LED_RED_OFF;
-        } else {
             HW_LED_BLUE_OFF; HW_LED_RED_ON;
+        } else {
+            HW_LED_BLUE_ON; HW_LED_RED_OFF;
         }
     }
 
@@ -187,8 +187,8 @@ mloop: // Main loop avoiding the GCC "optimization"
             //     millitimer(200 - (i * 10));
             //     HW_LED_RED_TOGGLE;
             // }
-            // HW_LED_RED_ON;
-            g_audio_output_is_enabled = false;
+            HW_LED_RED_ON;
+            g_audio_output_is_enabled = true;
             #if AUDIO_FEEDBACK_MODE == AUDIO_FEEDBACK_ON
                 playTone(MIDDLE_C * 4, 150, 25);
                 playTone(MIDDLE_C, 150, 25);

--- a/Software/Open_Theremin_V4/application.cpp
+++ b/Software/Open_Theremin_V4/application.cpp
@@ -107,9 +107,7 @@ void theremin_setup() {
     pinMode(LED_BLUE_PIN, OUTPUT);
     pinMode(LED_RED_PIN, OUTPUT);
 
-    // red LED indicates standby (muted)
-    // blue LED is lit during performance mode.
-    HW_LED_BLUE_OFF; HW_LED_RED_ON;
+    HW_LED_BLUE_ON; HW_LED_RED_OFF;
 
     // initialize potentiometer position at startup
     // force update for correct initialization
@@ -140,10 +138,8 @@ mloop: // Main loop avoiding the GCC "optimization"
         g_state = CALIBRATING;
         g_audio_output_is_enabled = !g_audio_output_is_enabled;
         if (g_audio_output_is_enabled) {
-            // blue LED indicates performance mode (play)
             HW_LED_BLUE_ON; HW_LED_RED_OFF;
         } else {
-            // red LED indicates mute (standby)
             HW_LED_BLUE_OFF; HW_LED_RED_ON;
         }
     }
@@ -154,10 +150,14 @@ mloop: // Main loop avoiding the GCC "optimization"
 
     if (g_state == CALIBRATING && timerExpired(UI_BUTTON_LONG_PRESS_DURATION)) {
         // signal the player to prepare for calibration
-        for (int i = 0; i<10; i++) {
-            millitimer(200 - (i * 10));
-            HW_LED_BLUE_TOGGLE; HW_LED_RED_TOGGLE;
-        }
+        // uncomment the following lines to have a countdown blink
+        // so that the user can move his/her hands away from the antennas
+        // TODO: update user manual if this function is to be included
+        //       in production.
+        // for (int i = 0; i<10; i++) {
+        //    millitimer(200 - (i * 10));
+        //    HW_LED_BLUE_TOGGLE; HW_LED_RED_TOGGLE;
+        // }
         // both LEDs indicate calibration mode
         HW_LED_BLUE_ON; HW_LED_RED_ON;
         // flag audio as disabled during calibration for coherence
@@ -172,7 +172,7 @@ mloop: // Main loop avoiding the GCC "optimization"
 
         bool success = calibration_start();
         if (success) {
-            HW_LED_BLUE_ON; HW_LED_RED_OFF;
+            //HW_LED_BLUE_ON; HW_LED_RED_OFF;
             g_audio_output_is_enabled = true;
             #if AUDIO_FEEDBACK_MODE == AUDIO_FEEDBACK_ON
                 playTone(MIDDLE_C * 2, 150, 25);
@@ -180,12 +180,14 @@ mloop: // Main loop avoiding the GCC "optimization"
             #endif
         } else {
             // visual feedback for failed calibration
-            HW_LED_BLUE_OFF;
-            for (int i = 0; i<10; i++) {
-                millitimer(200 - (i * 10));
-                HW_LED_RED_TOGGLE;
-            }
-            HW_LED_RED_ON;
+            // please uncomment the following lines
+            // to include this code in production
+            // HW_LED_BLUE_OFF;
+            // for (int i = 0; i<10; i++) {
+            //     millitimer(200 - (i * 10));
+            //     HW_LED_RED_TOGGLE;
+            // }
+            // HW_LED_RED_ON;
             g_audio_output_is_enabled = false;
             #if AUDIO_FEEDBACK_MODE == AUDIO_FEEDBACK_ON
                 playTone(MIDDLE_C * 4, 150, 25);

--- a/Software/Open_Theremin_V4/application.h
+++ b/Software/Open_Theremin_V4/application.h
@@ -1,45 +1,7 @@
 #ifndef _APPLICATION_H
 #define _APPLICATION_H
 
-#include <Arduino.h>
-
-#include "build.h"
-
-enum AppState { CALIBRATING = 0, PLAYING };
-enum AppMode { MUTE = 0, NORMAL };
-
-class Application {
-    public:
-    Application();
-    
-    void setup();
-    void loop();
-    
-    private:
-    static const uint16_t MAX_VOLUME = 4095;
-
-    int16_t pitch_p = -1; 
-    int32_t vol_p = -1;
-    bool gate_p = false;
-
-    AppState _state = PLAYING;
-    AppMode    _mode = MUTE;
-        
-    void calibrate();
-    void calibrate_pitch();
-    void calibrate_volume();
-    
-    unsigned long GetPitchMeasurement();
-    unsigned long GetVolumeMeasurement();
-    unsigned long GetQMeasurement();
-
-    const float HZ_ADDVAL_FACTOR = 2.09785;
-    const float MIDDLE_C = 261.6;
-
-    void playNote(float hz, uint16_t milliseconds, uint8_t volume);
-    void playStartupSound();
-    void playCalibratingCountdownSound();
-    void delay_NOP(unsigned long time);
-};
+void theremin_setup();
+void theremin_loop();
 
 #endif // _APPLICATION_H

--- a/Software/Open_Theremin_V4/calibration.cpp
+++ b/Software/Open_Theremin_V4/calibration.cpp
@@ -8,6 +8,7 @@
 
 
 // calibration
+#define DAC_12BIT_MAX 4095         // 12 bit DAC max clamping value
 #define PITCH_FIXED_OSCILLATOR_FREQUENCY        500000      // XTAL1 = 16 MHz / 32 (Q5 of U2 - 4060D)
 #define VOLUME_FIXED_OSCILLATOR_FREQUENCY       460800      // XTAL2 = 7.3728 MHz / 16 (Q4 of U3 - 4060D)
 #define CALIBRATION_BASE_MAX_DRIFT              150         // maximum drift from target frequency for success calibration
@@ -16,14 +17,32 @@ int32_t pitchCalibrationBase = 0;
 const int16_t PitchFreqOffset = 700;
 int32_t volCalibrationBase = 0;
 const int16_t VolumeFreqOffset = 700;
-const uint32_t master_clock_frequency = 16000000;
-
-#define DAC_12BIT_MAX 4095         // 12 bit DAC max clamping value
+static float qMeasurement = 0;
 
 
 /*******************************************
  *          CALIBRATION ROUTINES
  *******************************************/
+
+unsigned long GetQMeasurement() {
+  int qn = 0;
+  TCCR1B = (1 << CS10);
+  while (!(PIND & (1 << PORTD3)));
+  while ((PIND & (1 << PORTD3)));
+  TCNT1 = 0;
+  timer_overflow_counter = 0;
+  while (qn < 31250) {
+    while (!(PIND & (1 << PORTD3)));
+    qn++;
+    while ((PIND & (1 << PORTD3)));
+  }
+  TCCR1B = 0;
+  unsigned long frequency = TCNT1;
+  unsigned long temp = 65536 * (unsigned long)timer_overflow_counter;
+  frequency += temp;
+  return frequency;
+}
+
 
  
 /**
@@ -173,8 +192,8 @@ bool calibration_finalize() {
             #endif
 
             // check if calibration was within valid limits
-            float pitchBeatHz = master_clock_frequency / pitchCalibrationBase;
-            float volBeatHz = master_clock_frequency / volCalibrationBase;
+            float pitchBeatHz = qMeasurement / pitchCalibrationBase;
+            float volBeatHz = qMeasurement / volCalibrationBase;
             success = abs(pitchBeatHz - PitchFreqOffset) < CALIBRATION_BASE_MAX_DRIFT;
             if (success) {
                 success = abs(volBeatHz - VolumeFreqOffset) < CALIBRATION_BASE_MAX_DRIFT;
@@ -218,20 +237,31 @@ bool calibration_finalize() {
  * @see GetPitchMeasurement()
  */
 bool calibrate_pitch() {
-    int16_t pitchXn0 = 0;    // Lower DAC bound
-    int16_t pitchXn1 = DAC_12BIT_MAX;    // Upper DAC bound (max for 12-bit DAC)
-    int16_t pitchXn2 = 0;    // Midpoint in iteration
-    static const float q0 = (master_clock_frequency / master_clock_frequency * PITCH_FIXED_OSCILLATOR_FREQUENCY); // Count Timer1 ticks over 31.25k cycles
-    long pitchfn0 = 0;       // Measured pitch frequencies
+    int16_t pitchXn0 = 0;
+    int16_t pitchXn1 = DAC_12BIT_MAX;
+    int16_t pitchXn2 = 0;
+    float q0 = 0.f;
+    long pitchfn0 = 0;
     long pitchfn1 = 0;
-    long pitchfn = q0 - PitchFreqOffset;     // Correct for calibration drift
+    long pitchfn = 0;
 
     DEBUG_PRINTLN(F("\nPITCH CALIBRATION"));
     DEBUG_PRINT(F("Set f= ")); DEBUG_PRINTLN(pitchfn);
 
+    // UI FEEDBACK
+    HW_LED_BLUE_ON;
+    HW_LED_RED_ON;
+
     ihInitialisePitchMeasurement();     // Setup Timer1 and associated ISR flags
-    //sei();
+    sei();
     SPImcpDACinit();                    // Initialize DACs
+
+    qMeasurement = GetQMeasurement(); // Measure Arduino clock frequency
+    DEBUG_PRINT(F("X1="));DEBUG_PRINTLN(qMeasurement);
+    q0 = (16000000 / qMeasurement * PITCH_FIXED_OSCILLATOR_FREQUENCY); //Calculated set frequency based on Arudino clock frequency
+
+    pitchfn = q0 - PitchFreqOffset; // Add offset calue to set frequency
+    DEBUG_PRINT(F("Pitch Set frequency: "));DEBUG_PRINTLN(pitchfn);
 
     SPImcpDAC2Bsend(1600);          // bias the volume oscillator for pitch calibration
     SPImcpDAC2Asend(pitchXn0);      // Frequency at low DAC value
@@ -320,19 +350,22 @@ bool calibrate_volume() {
     int16_t volumeXn0 = 0;   // Lower DAC bound
     int16_t volumeXn1 = DAC_12BIT_MAX;   // Upper DAC bound
     int16_t volumeXn2 = 0;   // Next DAC trial value
-    // Calculate actual frequency from X2 crystal via prior master_clock_frequency (from X1 at 16 MHz)
-    // Target frequency: 7372800 / 16 = 460800
-    static const float q0 = (master_clock_frequency / master_clock_frequency * VOLUME_FIXED_OSCILLATOR_FREQUENCY);            // Calculated oscillator frequency based on crystal measurement
+
     int32_t volumefn0 = 0;      // Frequency measurements
     int32_t volumefn1 = 0;
-    int32_t volumefn = q0 - VolumeFreqOffset;
 
     DEBUG_PRINTLN(F("\nVOLUME CALIBRATION"));
-    DEBUG_PRINT("Vf="); DEBUG_PRINTLN(volumefn);
 
     ihInitialiseVolumeMeasurement();    // Configure Timer0 and related registers
-    //sei();
+    sei();
     SPImcpDACinit();                    // Re-initialize DAC interface
+
+    // Target frequency: 7372800 / 16 = 460800
+    float q0 = (16000000  / qMeasurement  * VOLUME_FIXED_OSCILLATOR_FREQUENCY);            // Calculated oscillator frequency based on crystal measurement
+    int32_t volumefn = q0 - VolumeFreqOffset;
+    DEBUG_PRINT(F("Vf=")); DEBUG_PRINTLN(volumefn);
+
+    DEBUG_PRINT(F("Volume Set Frequency: "));DEBUG_PRINTLN(volumefn);
 
     // Measure low and high frequency extremes for DAC sweep range
     SPImcpDAC2Bsend(volumeXn0);
@@ -368,6 +401,9 @@ bool calibrate_volume() {
     if (success) {
         EEPROM.put(EEPROM_VOLUME_DAC_VOLTAGE_ADDRESS, volumeXn0); // Store DAC value for volume oscillator compensation
     }
+
+    HW_LED_BLUE_ON;
+    HW_LED_RED_OFF;
     return success;
 }
 
@@ -385,6 +421,9 @@ bool calibration_start() {
     millitimer(100);
     if (success) {
         success = calibration_finalize();
+        DEBUG_PRINTLN(F("CAL OK"));
+    } else {
+        DEBUG_PRINTLN(F("CAL ERR"));
     }
     return success;
 }


### PR DESCRIPTION
Hi Urs,

I just tested the code and I can compile it with Arduino IDE without any issues. The GetQMeasurement function is now back in the code and its being used as it was to avoid those drift you mentioned.

Regarding the UI LED colors I do not have the manual here at hand so I went from memory - and did cancel the previous PR as I noticed that the audio should be active at power on (if I remember correctly) and the RED LED indicates the audio active function while the BLUE is on during MUTE state.

Apologies for the delay - it's a busy time for me - hope all is well now, but let me know if any other issues arises.
Cheers,
Luca